### PR TITLE
Fixed install_plugins function

### DIFF
--- a/5/debian-9/rootfs/libelasticsearch.sh
+++ b/5/debian-9/rootfs/libelasticsearch.sh
@@ -99,7 +99,7 @@ elasticsearch_initialize() {
         if [ -n "$plugins" ]; then
             local plugins_list
             plugins_list=$(tr ',;' ' ' <<< "${plugins}")
-            for plugin in "${plugins_list[@]}"; do
+            for plugin in ${plugins_list[@]}; do
                 info "Installing plugin: $plugin"
                 elasticsearch-plugin install -b -v "$plugin"
             done

--- a/5/ol-7/rootfs/libelasticsearch.sh
+++ b/5/ol-7/rootfs/libelasticsearch.sh
@@ -99,7 +99,7 @@ elasticsearch_initialize() {
         if [ -n "$plugins" ]; then
             local plugins_list
             plugins_list=$(tr ',;' ' ' <<< "${plugins}")
-            for plugin in "${plugins_list[@]}"; do
+            for plugin in ${plugins_list[@]}; do
                 info "Installing plugin: $plugin"
                 elasticsearch-plugin install -b -v "$plugin"
             done

--- a/6/debian-9/rootfs/libelasticsearch.sh
+++ b/6/debian-9/rootfs/libelasticsearch.sh
@@ -99,7 +99,7 @@ elasticsearch_initialize() {
         if [ -n "$plugins" ]; then
             local plugins_list
             plugins_list=$(tr ',;' ' ' <<< "${plugins}")
-            for plugin in "${plugins_list[@]}"; do
+            for plugin in ${plugins_list[@]}; do
                 info "Installing plugin: $plugin"
                 elasticsearch-plugin install -b -v "$plugin"
             done

--- a/6/ol-7/rootfs/libelasticsearch.sh
+++ b/6/ol-7/rootfs/libelasticsearch.sh
@@ -99,7 +99,7 @@ elasticsearch_initialize() {
         if [ -n "$plugins" ]; then
             local plugins_list
             plugins_list=$(tr ',;' ' ' <<< "${plugins}")
-            for plugin in "${plugins_list[@]}"; do
+            for plugin in ${plugins_list[@]}; do
                 info "Installing plugin: $plugin"
                 elasticsearch-plugin install -b -v "$plugin"
             done


### PR DESCRIPTION
**Description of the change**
Fixes the  "install_plugins" function to be able to install more than 1 plugin

**Benefits**
Can now install more than 1 plugin without causing an error

**Possible drawbacks**
None that i can think of

**Applicable issues**
None

**Additional information**
I removed the quotes from the for loop, this caused an input string like "plugin1;plugin2" to be printed as "plugin1 plugin2" on 1 line, instead of being printed on 2 seperate lines.

Tested with the following code locally:
```
#!/bin/bash
install_plugins() {
        local plugins="${1:-}"
        if [ -n "$plugins" ]; then
            local plugins_list
            plugins_list=$(tr ',;' ' ' <<< "${plugins}")
            echo $plugins_list
            for plugin in ${plugins_list[@]}; do
                echo "Installing plugin: $plugin"
            done
        fi
    }
install_plugins "test;123"
```
This would output:
```
test 123
Installing plugin: test
Installing plugin: 123
```
Old version would output:
```
Installing plugin: test 123
```