### PR TITLE
Set plugins as 'mandatory' on config file when they're set on ELASTICSEARCH_PLUGINS env var

### DIFF
--- a/5/debian-9/rootfs/libelasticsearch.sh
+++ b/5/debian-9/rootfs/libelasticsearch.sh
@@ -397,6 +397,7 @@ elasticsearch_initialize() {
 elasticsearch_install_plugins() {
     read -r -a plugins_list <<< "$(tr ',;' ' ' <<< "$ELASTICSEARCH_PLUGINS")"
     debug "Installing plugins: ${plugins_list[*]}"
+    elasticsearch_conf_set plugin.mandatory "$ELASTICSEARCH_PLUGINS"
     for plugin in "${plugins_list[@]}"; do
         debug "Installing plugin: $plugin"
         if [[ "${BITNAMI_DEBUG:-false}" = true ]]; then

--- a/5/ol-7/rootfs/libelasticsearch.sh
+++ b/5/ol-7/rootfs/libelasticsearch.sh
@@ -397,6 +397,7 @@ elasticsearch_initialize() {
 elasticsearch_install_plugins() {
     read -r -a plugins_list <<< "$(tr ',;' ' ' <<< "$ELASTICSEARCH_PLUGINS")"
     debug "Installing plugins: ${plugins_list[*]}"
+    elasticsearch_conf_set plugin.mandatory "$ELASTICSEARCH_PLUGINS"
     for plugin in "${plugins_list[@]}"; do
         debug "Installing plugin: $plugin"
         if [[ "${BITNAMI_DEBUG:-false}" = true ]]; then

--- a/6/debian-9/rootfs/libelasticsearch.sh
+++ b/6/debian-9/rootfs/libelasticsearch.sh
@@ -397,6 +397,7 @@ elasticsearch_initialize() {
 elasticsearch_install_plugins() {
     read -r -a plugins_list <<< "$(tr ',;' ' ' <<< "$ELASTICSEARCH_PLUGINS")"
     debug "Installing plugins: ${plugins_list[*]}"
+    elasticsearch_conf_set plugin.mandatory "$ELASTICSEARCH_PLUGINS"
     for plugin in "${plugins_list[@]}"; do
         debug "Installing plugin: $plugin"
         if [[ "${BITNAMI_DEBUG:-false}" = true ]]; then

--- a/6/ol-7/rootfs/libelasticsearch.sh
+++ b/6/ol-7/rootfs/libelasticsearch.sh
@@ -397,6 +397,7 @@ elasticsearch_initialize() {
 elasticsearch_install_plugins() {
     read -r -a plugins_list <<< "$(tr ',;' ' ' <<< "$ELASTICSEARCH_PLUGINS")"
     debug "Installing plugins: ${plugins_list[*]}"
+    elasticsearch_conf_set plugin.mandatory "$ELASTICSEARCH_PLUGINS"
     for plugin in "${plugins_list[@]}"; do
         debug "Installing plugin: $plugin"
         if [[ "${BITNAMI_DEBUG:-false}" = true ]]; then

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ elasticsearch:
 
 Available variables:
 
+ - `BITNAMI_DEBUG`: Increase verbosity on initialization logs. Default **false**
  - `ELASTICSEARCH_CLUSTER_NAME`: The Elasticsearch Cluster Name. Default: **elasticsearch-cluster**
  - `ELASTICSEARCH_CLUSTER_HOSTS`: List of elasticsearch hosts to set the cluster. Available separatos are ' ', ',' and ';'. No defaults.
  - `ELASTICSEARCH_IS_DEDICATED_NODE`: Elasticsearch node to behave as a 'dedicated node'. Default: **no**


### PR DESCRIPTION
### Why we need this change?

This PR ensures every plugin listed in the env. variable ELASTICSEARCH_PLUGINS is set as a mandatory plugin on ES configuration file

### What issue(s) this PR fixes?

- fixes https://github.com/bitnami/bitnami-docker-elasticsearch/issues/50