### PR TITLE
Add support for elasticsearch keys and repository-s3 plugin

### DIFF
--- a/6/debian-9/Dockerfile
+++ b/6/debian-9/Dockerfile
@@ -18,10 +18,12 @@ ENV BITNAMI_APP_NAME="elasticsearch" \
     BITNAMI_IMAGE_VERSION="6.8.3-debian-9-r31" \
     LD_LIBRARY_PATH="/opt/bitnami/elasticsearch/jdk/lib:/opt/bitnami/elasticsearch/jdk/lib/server:$LD_LIBRARY_PATH" \
     NAMI_PREFIX="/.nami" \
+    ELASTICSEARCH_DAEMON_USER="1001" \
+    ELASTICSEARCH_DAEMON_GROUP="root" \
+    BITNAMI_DEBUG="false" \
     PATH="/opt/bitnami/java/bin:/opt/bitnami/elasticsearch/bin:$PATH"
 
 EXPOSE 9200 9300
 
-USER 1001
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "/run.sh" ]

--- a/6/debian-9/rootfs/libelasticsearch.sh
+++ b/6/debian-9/rootfs/libelasticsearch.sh
@@ -146,6 +146,7 @@ export ELASTICSEARCH_NODE_PORT_NUMBER="${ELASTICSEARCH_NODE_PORT_NUMBER:-9300}"
 export ELASTICSEARCH_NODE_TYPE="${ELASTICSEARCH_NODE_TYPE:-master}"
 export ELASTICSEARCH_PLUGINS="${ELASTICSEARCH_PLUGINS:-}"
 export ELASTICSEARCH_PORT_NUMBER="${ELASTICSEARCH_PORT_NUMBER:-9200}"
+export ELASTICSEARCH_KEYS="${ELASTICSEARCH_KEYS:-}"
 EOF
 }
 
@@ -409,6 +410,7 @@ elasticsearch_initialize() {
         ensure_dir_exists "$dir"
         am_i_root && chown -R "$ELASTICSEARCH_DAEMON_USER:$ELASTICSEARCH_DAEMON_GROUP" "$dir"
     done
+    am_i_root && chown "$ELASTICSEARCH_DAEMON_USER:$ELASTICSEARCH_DAEMON_GROUP" "${ELASTICSEARCH_CONFDIR}/jvm.options"
 
     if [[ -f "$ELASTICSEARCH_CONF_FILE" ]]; then
         info "Custom configuration file detected, using it..."
@@ -437,7 +439,6 @@ elasticsearch_initialize() {
 elasticsearch_install_plugins() {
     read -r -a plugins_list <<< "$(tr ',;' ' ' <<< "$ELASTICSEARCH_PLUGINS")"
     debug "Installing plugins: ${plugins_list[*]}"
-    elasticsearch_conf_set plugin.mandatory "$ELASTICSEARCH_PLUGINS"
     for plugin in "${plugins_list[@]}"; do
         debug "Installing plugin: $plugin"
         if [[ "${BITNAMI_DEBUG:-false}" = true ]]; then
@@ -446,4 +447,29 @@ elasticsearch_install_plugins() {
             elasticsearch-plugin install -b -v "$plugin" >/dev/null 2>&1
         fi
     done
+}
+
+########################
+# Add storage keys
+# Globals:
+#   ELASTICSEARCH_KEYS
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+elasticsearch_add_keys() {
+    read -r -a keys_list <<< "$(tr ';' ' ' <<< "$ELASTICSEARCH_KEYS")"
+    debug "Adding keys: ${keys_list[*]}"
+    elasticsearch-keystore create
+    for key in "${keys_list[@]}"; do
+        debug "Add key: $key"
+        read -r -a key_value <<< "$(tr ',' ' ' <<< "$key")"
+        if [[ "${BITNAMI_DEBUG:-false}" = true ]]; then
+            echo ${key_value[1]} | elasticsearch-keystore add --stdin ${key_value[0]}
+        else
+            echo ${key_value[1]} | elasticsearch-keystore add --stdin ${key_value[0]} >/dev/null 2>&1
+        fi
+    done
+    am_i_root && chown "$ELASTICSEARCH_DAEMON_USER:$ELASTICSEARCH_DAEMON_GROUP" "${ELASTICSEARCH_CONFDIR}/elasticsearch.keystore"
 }

--- a/6/debian-9/rootfs/setup.sh
+++ b/6/debian-9/rootfs/setup.sh
@@ -28,3 +28,7 @@ elasticsearch_initialize
 if [[ -n "$ELASTICSEARCH_PLUGINS" ]]; then
     elasticsearch_install_plugins
 fi
+
+if [[ -n "$ELASTICSEARCH_KEYS" ]]; then
+    elasticsearch_add_keys
+fi

--- a/6/ol-7/Dockerfile
+++ b/6/ol-7/Dockerfile
@@ -18,10 +18,12 @@ ENV BITNAMI_APP_NAME="elasticsearch" \
     BITNAMI_IMAGE_VERSION="6.8.3-ol-7-r34" \
     LD_LIBRARY_PATH="/opt/bitnami/elasticsearch/jdk/lib:/opt/bitnami/elasticsearch/jdk/lib/server:$LD_LIBRARY_PATH" \
     NAMI_PREFIX="/.nami" \
+    ELASTICSEARCH_DAEMON_USER="1001" \
+    ELASTICSEARCH_DAEMON_GROUP="root" \
+    BITNAMI_DEBUG="false" \
     PATH="/opt/bitnami/java/bin:/opt/bitnami/elasticsearch/bin:$PATH"
 
 EXPOSE 9200 9300
 
-USER 1001
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "/run.sh" ]

--- a/6/ol-7/rootfs/setup.sh
+++ b/6/ol-7/rootfs/setup.sh
@@ -20,11 +20,13 @@ elasticsearch_validate_kernel
 elasticsearch_validate
 # Ensure Elasticsearch is stopped when this script ends
 trap "elasticsearch_stop" EXIT
-# Ensure 'daemon' user exists when running as 'root'
-am_i_root && ensure_user_exists "$ELASTICSEARCH_DAEMON_USER" "$ELASTICSEARCH_DAEMON_GROUP"
 # Ensure Elasticsearch is initialized
 elasticsearch_initialize
 # Install Elasticsearch plugins
 if [[ -n "$ELASTICSEARCH_PLUGINS" ]]; then
     elasticsearch_install_plugins
+fi
+
+if [[ -n "$ELASTICSEARCH_KEYS" ]]; then
+    elasticsearch_add_keys
 fi


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This change is for fixing #64 and it adds support for elasticsearch keys. Besides that, it fixes a bug during installing elasticsearch plugins using links (like [this](https://github.com/NarimanN2/ParsiAnalyzer) plugin) and permission issue when installing repository-s3 plugin that discussed [here](https://github.com/elastic/elasticsearch/issues/40969).

**Benefits**

- installing plugins using link and file path
- installing plugins that need some additional permissions like repository-s3 plugin
- adding keys using elasticsearch-keystore in Dockerfile

**Possible drawbacks**

Because I removed elasticsearch_conf_set line in plugin installation, might cause some problem, don't know!