### PR TITLE
Fix elasticsearch_conf_write function for arrays

### DIFF
--- a/6/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/6/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -58,7 +58,7 @@ elasticsearch_conf_set() {
     else
         for i in "${!values[@]}"; do
             if [[ -n "${values[$i]}" ]]; then
-                elasticsearch_conf_write "$key" "${values[$i]}"
+                elasticsearch_conf_write "${key}[+]" "${values[$i]}"
             fi
         done
     fi

--- a/7/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -58,7 +58,7 @@ elasticsearch_conf_set() {
     else
         for i in "${!values[@]}"; do
             if [[ -n "${values[$i]}" ]]; then
-                elasticsearch_conf_write "$key" "${values[$i]}"
+                elasticsearch_conf_write "${key}[+]" "${values[$i]}"
             fi
         done
     fi


### PR DESCRIPTION
**Description of the change**

This PR fixes an issue when using `elasticsearch_conf_write` to set arrays

**Benefits**

Arrays are correctly set

**Possible drawbacks**

None

