### PR TITLE
fix: add path.repo setting from ELASTICSEARCH_REPO_DIR optional envvar

### DIFF
--- a/6/debian-10/rootfs/opt/bitnami/scripts/elasticsearch/postunpack.sh
+++ b/6/debian-10/rootfs/opt/bitnami/scripts/elasticsearch/postunpack.sh
@@ -9,7 +9,10 @@
 # Load Elasticsearch environment variables
 eval "$(elasticsearch_env)"
 
-for dir in "$ELASTICSEARCH_TMP_DIR" "$ELASTICSEARCH_DATA_DIR" "$ELASTICSEARCH_LOG_DIR" "${ELASTICSEARCH_BASE_DIR}/plugins" "${ELASTICSEARCH_BASE_DIR}/modules" "$ELASTICSEARCH_CONF_DIR" "$ELASTICSEARCH_VOLUME_DIR" "$ELASTICSEARCH_INITSCRIPTS_DIR" "$ELASTICSEARCH_MOUNTED_PLUGINS_DIR"; do
+# Allow some of below env vars to be empty, skip if so
+set +o nounset
+for dir in "$ELASTICSEARCH_TMP_DIR" "$ELASTICSEARCH_DATA_DIR" "$ELASTICSEARCH_REPO_DIR" "$ELASTICSEARCH_LOG_DIR" "${ELASTICSEARCH_BASE_DIR}/plugins" "${ELASTICSEARCH_BASE_DIR}/modules" "$ELASTICSEARCH_CONF_DIR" "$ELASTICSEARCH_VOLUME_DIR" "$ELASTICSEARCH_INITSCRIPTS_DIR" "$ELASTICSEARCH_MOUNTED_PLUGINS_DIR"; do
+    test -z "$dir" && continue
     ensure_dir_exists "$dir"
     chmod -R ug+rwX "$dir"
     # `elasticsearch-plugin install` command complains about being unable to create the a plugin's directory

--- a/6/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/6/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -439,6 +439,7 @@ elasticsearch_initialize() {
         touch "$ELASTICSEARCH_CONF_FILE"
         elasticsearch_conf_set http.port "$ELASTICSEARCH_PORT_NUMBER"
         elasticsearch_conf_set path.data "$ELASTICSEARCH_DATA_DIR"
+        test -n "$ELASTICSEARCH_REPO_DIR" && elasticsearch_conf_set path.repo "$ELASTICSEARCH_REPO_DIR"
         elasticsearch_conf_set transport.tcp.port "$ELASTICSEARCH_NODE_PORT_NUMBER"
         elasticsearch_cluster_configuration
         elasticsearch_configure_node_type

--- a/7/debian-10/rootfs/opt/bitnami/scripts/elasticsearch/postunpack.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/elasticsearch/postunpack.sh
@@ -9,7 +9,10 @@
 # Load Elasticsearch environment variables
 eval "$(elasticsearch_env)"
 
-for dir in "$ELASTICSEARCH_TMP_DIR" "$ELASTICSEARCH_DATA_DIR" "$ELASTICSEARCH_LOG_DIR" "${ELASTICSEARCH_BASE_DIR}/plugins" "${ELASTICSEARCH_BASE_DIR}/modules" "$ELASTICSEARCH_CONF_DIR" "$ELASTICSEARCH_VOLUME_DIR" "$ELASTICSEARCH_INITSCRIPTS_DIR" "$ELASTICSEARCH_MOUNTED_PLUGINS_DIR"; do
+# Allow some of below env vars to be empty, skip if so
+set +o nounset
+for dir in "$ELASTICSEARCH_TMP_DIR" "$ELASTICSEARCH_DATA_DIR" "$ELASTICSEARCH_REPO_DIR" "$ELASTICSEARCH_LOG_DIR" "${ELASTICSEARCH_BASE_DIR}/plugins" "${ELASTICSEARCH_BASE_DIR}/modules" "$ELASTICSEARCH_CONF_DIR" "$ELASTICSEARCH_VOLUME_DIR" "$ELASTICSEARCH_INITSCRIPTS_DIR" "$ELASTICSEARCH_MOUNTED_PLUGINS_DIR"; do
+    test -z "$dir" && continue
     ensure_dir_exists "$dir"
     chmod -R ug+rwX "$dir"
     # `elasticsearch-plugin install` command complains about being unable to create the a plugin's directory

--- a/7/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -439,6 +439,7 @@ elasticsearch_initialize() {
         touch "$ELASTICSEARCH_CONF_FILE"
         elasticsearch_conf_set http.port "$ELASTICSEARCH_PORT_NUMBER"
         elasticsearch_conf_set path.data "$ELASTICSEARCH_DATA_DIR"
+        test -n "$ELASTICSEARCH_REPO_DIR" && elasticsearch_conf_set path.repo "$ELASTICSEARCH_REPO_DIR"
         elasticsearch_conf_set transport.tcp.port "$ELASTICSEARCH_NODE_PORT_NUMBER"
         elasticsearch_cluster_configuration
         elasticsearch_configure_node_type

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ docker run \
 or by making a minor change to the [`docker-compose.yml`](https://github.com/bitnami/bitnami-docker-elasticsearch/blob/master/docker-compose.yml) file present in this repository:
 
 ```yaml
-mariadb:
+elasticsearch:
   ...
   volumes:
     - /path/to/elasticsearch-data-persistence:/bitnami/elasticsearch/data


### PR DESCRIPTION
Fixes #73.

**Description of the change**

Allow auto-generated elasticsearch.yml `path.repo` to be setup
via ELASTICSEARCH_REPO_DIR env var

**Benefits**

Any elasticsearch snapshot operation requires `path.repo`, this
provides ability to set it.

**Possible drawbacks**

None, obviously same case as `path.data` re: user needing to setup the
container persistence accordingly.

**Applicable issues**

See
https://www.elastic.co/guide/en/elasticsearch/reference/6.7/modules-snapshots.html#_shared_file_system_repository