### PR TITLE
Add environment variable to configure 'File System snapshot repository path'

### DIFF
--- a/6/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/6/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -149,6 +149,7 @@ elasticsearch_start() {
 #########################
 elasticsearch_env() {
     cat <<"EOF"
+# Paths
 export ELASTICSEARCH_BASE_DIR="/opt/bitnami/elasticsearch"
 export ELASTICSEARCH_VOLUME_DIR="/bitnami/elasticsearch"
 export ELASTICSEARCH_DATA_DIR="${ELASTICSEARCH_VOLUME_DIR}/data"
@@ -159,8 +160,12 @@ export ELASTICSEARCH_CONF_FILE="${ELASTICSEARCH_CONF_DIR}/elasticsearch.yml"
 export ELASTICSEARCH_TMP_DIR="${ELASTICSEARCH_BASE_DIR}/tmp"
 export ELASTICSEARCH_LOG_DIR="${ELASTICSEARCH_BASE_DIR}/logs"
 export PATH="${ELASTICSEARCH_BASE_DIR}/bin:$PATH"
+
+# Users
 export ELASTICSEARCH_DAEMON_USER="${ELASTICSEARCH_DAEMON_USER:-elasticsearch}"
 export ELASTICSEARCH_DAEMON_GROUP="${ELASTICSEARCH_DAEMON_GROUP:-elasticsearch}"
+
+# Settings
 export ELASTICSEARCH_BIND_ADDRESS="${ELASTICSEARCH_BIND_ADDRESS:-}"
 export ELASTICSEARCH_CLUSTER_HOSTS="${ELASTICSEARCH_CLUSTER_HOSTS:-}"
 export ELASTICSEARCH_TOTAL_NODES="${ELASTICSEARCH_TOTAL_NODES:-}"
@@ -174,6 +179,8 @@ export ELASTICSEARCH_NODE_PORT_NUMBER="${ELASTICSEARCH_NODE_PORT_NUMBER:-9300}"
 export ELASTICSEARCH_NODE_TYPE="${ELASTICSEARCH_NODE_TYPE:-master}"
 export ELASTICSEARCH_PLUGINS="${ELASTICSEARCH_PLUGINS:-}"
 export ELASTICSEARCH_PORT_NUMBER="${ELASTICSEARCH_PORT_NUMBER:-9200}"
+export ELASTICSEARCH_FS_SNAPSHOT_REPO_PATH="${ELASTICSEARCH_FS_SNAPSHOT_REPO_PATH:-}"
+
 ## JVM
 export JAVA_HOME="${JAVA_HOME:-/opt/bitnami/java}"
 EOF
@@ -272,6 +279,7 @@ elasticsearch_cluster_configuration() {
     elasticsearch_conf_set network.bind_host "$(bind_address)"
     elasticsearch_conf_set cluster.name "$ELASTICSEARCH_CLUSTER_NAME"
     elasticsearch_conf_set node.name "${ELASTICSEARCH_NODE_NAME:-$(hostname)}"
+
     if [[ -n "$ELASTICSEARCH_CLUSTER_HOSTS" ]]; then
         read -r -a host_list <<< "$(tr ',;' ' ' <<< "$ELASTICSEARCH_CLUSTER_HOSTS")"
         master_list=( "${host_list[@]}" )
@@ -347,6 +355,12 @@ elasticsearch_configure_node_type() {
     elasticsearch_conf_set node.master "$is_master"
     elasticsearch_conf_set node.data "$is_data"
     elasticsearch_conf_set node.ingest "$is_ingest"
+    if [[ "$is_data" = "true" || "$is_master" = "true" ]] && [[ -n "$ELASTICSEARCH_FS_SNAPSHOT_REPO_PATH" ]]; then
+        # Configure path.repo to restore snapshots from system repository
+        # It must be set on every master an data node
+        # ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshots-register-repository.html#snapshots-filesystem-repository
+        elasticsearch_conf_set path.repo "$ELASTICSEARCH_FS_SNAPSHOT_REPO_PATH"
+    fi
 }
 
 ########################

--- a/7/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -149,6 +149,7 @@ elasticsearch_start() {
 #########################
 elasticsearch_env() {
     cat <<"EOF"
+# Paths
 export ELASTICSEARCH_BASE_DIR="/opt/bitnami/elasticsearch"
 export ELASTICSEARCH_VOLUME_DIR="/bitnami/elasticsearch"
 export ELASTICSEARCH_DATA_DIR="${ELASTICSEARCH_VOLUME_DIR}/data"
@@ -159,8 +160,12 @@ export ELASTICSEARCH_CONF_FILE="${ELASTICSEARCH_CONF_DIR}/elasticsearch.yml"
 export ELASTICSEARCH_TMP_DIR="${ELASTICSEARCH_BASE_DIR}/tmp"
 export ELASTICSEARCH_LOG_DIR="${ELASTICSEARCH_BASE_DIR}/logs"
 export PATH="${ELASTICSEARCH_BASE_DIR}/bin:$PATH"
+
+# Users
 export ELASTICSEARCH_DAEMON_USER="${ELASTICSEARCH_DAEMON_USER:-elasticsearch}"
 export ELASTICSEARCH_DAEMON_GROUP="${ELASTICSEARCH_DAEMON_GROUP:-elasticsearch}"
+
+# Settings
 export ELASTICSEARCH_BIND_ADDRESS="${ELASTICSEARCH_BIND_ADDRESS:-}"
 export ELASTICSEARCH_CLUSTER_HOSTS="${ELASTICSEARCH_CLUSTER_HOSTS:-}"
 export ELASTICSEARCH_TOTAL_NODES="${ELASTICSEARCH_TOTAL_NODES:-}"
@@ -174,6 +179,8 @@ export ELASTICSEARCH_NODE_PORT_NUMBER="${ELASTICSEARCH_NODE_PORT_NUMBER:-9300}"
 export ELASTICSEARCH_NODE_TYPE="${ELASTICSEARCH_NODE_TYPE:-master}"
 export ELASTICSEARCH_PLUGINS="${ELASTICSEARCH_PLUGINS:-}"
 export ELASTICSEARCH_PORT_NUMBER="${ELASTICSEARCH_PORT_NUMBER:-9200}"
+export ELASTICSEARCH_FS_SNAPSHOT_REPO_PATH="${ELASTICSEARCH_FS_SNAPSHOT_REPO_PATH:-}"
+
 ## JVM
 export JAVA_HOME="${JAVA_HOME:-/opt/bitnami/java}"
 EOF
@@ -272,6 +279,7 @@ elasticsearch_cluster_configuration() {
     elasticsearch_conf_set network.bind_host "$(bind_address)"
     elasticsearch_conf_set cluster.name "$ELASTICSEARCH_CLUSTER_NAME"
     elasticsearch_conf_set node.name "${ELASTICSEARCH_NODE_NAME:-$(hostname)}"
+
     if [[ -n "$ELASTICSEARCH_CLUSTER_HOSTS" ]]; then
         read -r -a host_list <<< "$(tr ',;' ' ' <<< "$ELASTICSEARCH_CLUSTER_HOSTS")"
         master_list=( "${host_list[@]}" )
@@ -347,6 +355,12 @@ elasticsearch_configure_node_type() {
     elasticsearch_conf_set node.master "$is_master"
     elasticsearch_conf_set node.data "$is_data"
     elasticsearch_conf_set node.ingest "$is_ingest"
+    if [[ "$is_data" = "true" || "$is_master" = "true" ]] && [[ -n "$ELASTICSEARCH_FS_SNAPSHOT_REPO_PATH" ]]; then
+        # Configure path.repo to restore snapshots from system repository
+        # It must be set on every master an data node
+        # ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshots-register-repository.html#snapshots-filesystem-repository
+        elasticsearch_conf_set path.repo "$ELASTICSEARCH_FS_SNAPSHOT_REPO_PATH"
+    fi
 }
 
 ########################

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ $ docker-compose up -d
 
 When you start the elasticsearch image, you can adjust the configuration of the instance by passing one or more environment variables either on the docker-compose file or on the `docker run` command line. If you want to add a new environment variable:
 
- * For Docker Compose, add the variable name and value under the application section:
+* For Docker Compose, add the variable name and value under the application section:
 
 ```yaml
 elasticsearch:
@@ -178,7 +178,7 @@ elasticsearch:
   ...
 ```
 
- * For manual execution add a `-e` option with each variable and value:
+* For manual execution add a `-e` option with each variable and value:
 
 ```console
  $ docker run -d --name elasticsearch \
@@ -190,36 +190,37 @@ elasticsearch:
 
 Available variables:
 
- - `BITNAMI_DEBUG`: Increase verbosity on initialization logs. Default **false**
- - `ELASTICSEARCH_EXTRA_FLAGS`: Extra command-line arguments for the `elasticsearch` daemon
- - `ELASTICSEARCH_CLUSTER_NAME`: The Elasticsearch Cluster Name. Default: **elasticsearch-cluster**
- - `ELASTICSEARCH_CLUSTER_HOSTS`: List of elasticsearch hosts to set the cluster. Available separators are ' ', ',' and ';'. No defaults.
- - `ELASTICSEARCH_CLUSTER_MASTER_HOSTS`: List of elasticsearch master-eligible hosts. Available separators are ' ', ',' and ';'. If no values are provided, it will have the same value than `ELASTICSEARCH_CLUSTER_HOSTS`.
- - `ELASTICSEARCH_IS_DEDICATED_NODE`: Elasticsearch node to behave as a 'dedicated node'. Default: **no**
- - `ELASTICSEARCH_NODE_TYPE`: Elasticsearch node type when behaving as a 'dedicated node'. Valid values: *master*, *data*, *coordinating* or *ingest*.
- - `ELASTICSEARCH_NODE_NAME`: Elasticsearch node name. No defaults.
- - `ELASTICSEARCH_BIND_ADDRESS`: Address/interface to bind by Elasticsearch. Default: **0.0.0.0**
- - `ELASTICSEARCH_PORT_NUMBER`: Elasticsearch port. Default: **9200**
- - `ELASTICSEARCH_NODE_PORT_NUMBER`: Elasticsearch Node to Node port. Default: **9300**
- - `ELASTICSEARCH_PLUGINS`: Comma, semi-colon or space separated list of plugins to install at initialization. No defaults.
- - `ELASTICSEARCH_HEAP_SIZE`: Memory used for the Xmx and Xms java heap values. Default: **1024m**
+* `BITNAMI_DEBUG`: Increase verbosity on initialization logs. Default **false**
+* `ELASTICSEARCH_EXTRA_FLAGS`: Extra command-line arguments for the `elasticsearch` daemon
+* `ELASTICSEARCH_CLUSTER_NAME`: The Elasticsearch Cluster Name. Default: **elasticsearch-cluster**
+* `ELASTICSEARCH_CLUSTER_HOSTS`: List of elasticsearch hosts to set the cluster. Available separators are ' ', ',' and ';'. No defaults.
+* `ELASTICSEARCH_CLUSTER_MASTER_HOSTS`: List of elasticsearch master-eligible hosts. Available separators are ' ', ',' and ';'. If no values are provided, it will have the same value than `ELASTICSEARCH_CLUSTER_HOSTS`.
+* `ELASTICSEARCH_IS_DEDICATED_NODE`: Elasticsearch node to behave as a 'dedicated node'. Default: **no**
+* `ELASTICSEARCH_NODE_TYPE`: Elasticsearch node type when behaving as a 'dedicated node'. Valid values: *master*, *data*, *coordinating* or *ingest*.
+* `ELASTICSEARCH_NODE_NAME`: Elasticsearch node name. No defaults.
+* `ELASTICSEARCH_BIND_ADDRESS`: Address/interface to bind by Elasticsearch. Default: **0.0.0.0**
+* `ELASTICSEARCH_PORT_NUMBER`: Elasticsearch port. Default: **9200**
+* `ELASTICSEARCH_NODE_PORT_NUMBER`: Elasticsearch Node to Node port. Default: **9300**
+* `ELASTICSEARCH_PLUGINS`: Comma, semi-colon or space separated list of plugins to install at initialization. No defaults.
+* `ELASTICSEARCH_HEAP_SIZE`: Memory used for the Xmx and Xms java heap values. Default: **1024m**
+* `ELASTICSEARCH_FS_SNAPSHOT_REPO_PATH`: Elasticsearch file system snapshot repository path. No defaults.
 
 ## Setting up a cluster
 
 A cluster can easily be setup with the Bitnami Elasticsearch Docker Image using the following environment variables:
 
- - `ELASTICSEARCH_CLUSTER_NAME`: The Elasticsearch Cluster Name. Default: **elasticsearch-cluster**
- - `ELASTICSEARCH_CLUSTER_HOSTS`: List of elasticsearch hosts to set the cluster. Available separators are ' ', ',' and ';'. No defaults.
- - `ELASTICSEARCH_CLIENT_NODE`: Elasticsearch node to behave as a 'smart router' for Kibana app. Default: **false**
- - `ELASTICSEARCH_NODE_NAME`: Elasticsearch node name. No defaults.
- - `ELASTICSEARCH_MINIMUM_MASTER_NODES`: Minimum Elasticsearch master nodes for quorum. No defaults.
+* `ELASTICSEARCH_CLUSTER_NAME`: The Elasticsearch Cluster Name. Default: **elasticsearch-cluster**
+* `ELASTICSEARCH_CLUSTER_HOSTS`: List of elasticsearch hosts to set the cluster. Available separators are ' ', ',' and ';'. No defaults.
+* `ELASTICSEARCH_CLIENT_NODE`: Elasticsearch node to behave as a 'smart router' for Kibana app. Default: **false**
+* `ELASTICSEARCH_NODE_NAME`: Elasticsearch node name. No defaults.
+* `ELASTICSEARCH_MINIMUM_MASTER_NODES`: Minimum Elasticsearch master nodes for quorum. No defaults.
 
 For larger cluster, you can setup 'dedicated nodes' using the following environment variables:
 
- - `ELASTICSEARCH_IS_DEDICATED_NODE`: Elasticsearch node to behave as a 'dedicated node'. Default: **no**
- - `ELASTICSEARCH_NODE_TYPE`: Elasticsearch node type when behaving as a 'dedicated node'. Valid values: *master*, *data*, *coordinating* or *ingest*.
- - `ELASTICSEARCH_CLUSTER_MASTER_HOSTS`: List of elasticsearch master-eligible hosts. Available separators are ' ', ',' and ';'. If no values are provided, it will have the same value than `ELASTICSEARCH_CLUSTER_HOSTS`.
- - `ELASTICSEARCH_TOTAL_NODES`: Number of master + data nodes, it's used to calculate `gateway.expected_nodes` and `gateway.recover_after_nodes` parameters. If not set, those parameters are calculated using `ELASTICSEARCH_CLUSTER_HOSTS`. No defaults.
+* `ELASTICSEARCH_IS_DEDICATED_NODE`: Elasticsearch node to behave as a 'dedicated node'. Default: **no**
+* `ELASTICSEARCH_NODE_TYPE`: Elasticsearch node type when behaving as a 'dedicated node'. Valid values: *master*, *data*, *coordinating* or *ingest*.
+* `ELASTICSEARCH_CLUSTER_MASTER_HOSTS`: List of elasticsearch master-eligible hosts. Available separators are ' ', ',' and ';'. If no values are provided, it will have the same value than `ELASTICSEARCH_CLUSTER_HOSTS`.
+* `ELASTICSEARCH_TOTAL_NODES`: Number of master + data nodes, it's used to calculate `gateway.expected_nodes` and `gateway.recover_after_nodes` parameters. If not set, those parameters are calculated using `ELASTICSEARCH_CLUSTER_HOSTS`. No defaults.
 
 Find more information about 'dedicated nodes' in the [official documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html).
 


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR adds support for a new environment variable `ELASTICSEARCH_FS_SNAPSHOT_REPO_PATH` to set the `path.repo` setting.

This is useful to configure the 'File System snapshot repository path'. More information at: https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshots-register-repository.html#snapshots-filesystem-repository

**Benefits**

You can recover ElasticSearch from snapshots.

**Possible drawbacks**

None

**Applicable issues**

- fixes https://github.com/bitnami/bitnami-docker-elasticsearch/issues/73 

**Additional information**

Tested using the changes in the ES chart you can found here: https://github.com/bitnami/charts/pull/2570

- Build custom ES based on these changes:

```console
$ cd 7/debian-10
$ docker build . -t juanariza131/elasticsearch:7
$ docker push juanariza131/elasticsearch:7
```

- Launch ES using the chart:

```console
$ cat > values.yaml << 'EOF' 
extraVolumes:
  - name: snapshot-repository
    emptyDir: {}
extraVolumeMounts:
  - name: snapshot-repository
    mountPath: /snapshots
snapshotRepoPath: "/snapshots"
image:
  repository: juanariza131/elasticsearch
  tag: 7
  pullPolicy: Always
EOF
$ helm install -f values.yaml elasticsearch bitnami/elasticsearch
$ kubectl exec $(kubectl get pods -l app.kubernetes.io/component=master -o jsonpath='{.items[0].metadata.name}') -- yq read /opt/bitnami/elasticsearch/config/elasticsearch.yml path
data: /bitnami/elasticsearch/data
repo: /snapshots
$ kubectl exec $(kubectl get pods -l app.kubernetes.io/component=data -o jsonpath='{.items[0].metadata.name}') -- yq read /opt/bitnami/elasticsearch/config/elasticsearch.yml path
data: /bitnami/elasticsearch/data
repo: /snapshots
$ kubectl exec $(kubectl get pods -l app.kubernetes.io/component=coordinating-only -o jsonpath='{.items[0].metadata.name}') -- yq read /opt/bitnami/elasticsearch/config/elasticsearch.yml path
data: /bitnami/elasticsearch/data
```