### PR TITLE
Support adding custom, bonus config to cluster's elasticsearch.yml

### DIFF
--- a/6/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/6/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -318,6 +318,22 @@ elasticsearch_cluster_configuration() {
 }
 
 ########################
+# Extend Elasticsearch cluster settings with custom, user-provided config
+# Globals:
+#  ELASTICSEARCH_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+elasticsearch_custom_configuration() {
+    local custom_conf_file="${ELASTICSEARCH_CONF_DIR}/my_elasticsearch.yml"
+    [[ ! -f "$custom_conf_file" ]] && return
+    info "Adding custom configuration"
+    yq m -ix "$ELASTICSEARCH_CONF_FILE" "$custom_conf_file"
+}
+
+########################
 # Configure Elasticsearch node type
 # Globals:
 #  ELASTICSEARCH_*
@@ -457,6 +473,7 @@ elasticsearch_initialize() {
         elasticsearch_conf_set transport.tcp.port "$ELASTICSEARCH_NODE_PORT_NUMBER"
         elasticsearch_cluster_configuration
         elasticsearch_configure_node_type
+        elasticsearch_custom_configuration
     fi
     elasticsearch_set_heap_size
 }

--- a/7/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -317,6 +317,23 @@ elasticsearch_cluster_configuration() {
     fi
 }
 
+
+########################
+# Extend Elasticsearch cluster settings with custom, user-provided config
+# Globals:
+#  ELASTICSEARCH_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+elasticsearch_custom_configuration() {
+    local custom_conf_file="${ELASTICSEARCH_CONF_DIR}/my_elasticsearch.yml"
+    [[ ! -f "$custom_conf_file" ]] && return
+    info "Adding custom configuration"
+    yq m -ix "$ELASTICSEARCH_CONF_FILE" "$custom_conf_file"
+}
+
 ########################
 # Configure Elasticsearch node type
 # Globals:
@@ -457,6 +474,7 @@ elasticsearch_initialize() {
         elasticsearch_conf_set transport.tcp.port "$ELASTICSEARCH_NODE_PORT_NUMBER"
         elasticsearch_cluster_configuration
         elasticsearch_configure_node_type
+        elasticsearch_custom_configuration
     fi
     elasticsearch_set_heap_size
 }

--- a/README.md
+++ b/README.md
@@ -282,8 +282,7 @@ services:
 
 ### Configuration file
 
-In order to use a custom configuration file instead of the default one provided out of the box, you can create a file named `elasticsearch.yml` and mount it at `/opt/bitnami/elasticsearch/config/elasticsearch.yml` to overwrite the default configuration.
-Please, note that the whole configuration file will be replaced by the provided one, ensure that the syntax and fields are properly set.
+In order to use a custom configuration file instead of the default one provided out of the box, you can create a file named `elasticsearch.yml` and mount it at `/opt/bitnami/elasticsearch/config/elasticsearch.yml` to overwrite the default configuration:
 
 ```console
 $ docker run -d --name elasticsearch \
@@ -303,6 +302,10 @@ elasticsearch:
     - /path/to/elasticsearch-data-persistence:/bitnami/elasticsearch/data
   ...
 ```
+
+Please, note that the whole configuration file will be replaced by the provided, default one; ensure that the syntax and fields you provide are properly set and exhaustive.
+
+If you would rather extend than replace the default configuration with your settings, mount your custom configuration file at `/opt/bitnami/elasticsearch/config/my_elasticsearch.yml`.
 
 ### Plugins
 


### PR DESCRIPTION
**Description of the change**

Allows to _extend_ the cluster's default configuration with custom, user-provided settings.

**Benefits**

It allows to safely customize the ES cluster/nodes without the need to replace, mimic & maintain conformity with the default config.

**Possible drawbacks**

User may provide incorrect custom settings, resulting in a broken ES cluster. It's already the case with the current approach of replacing the default configuration altogether, so it's nothing one should be worried about.

**Applicable issues**

None found.

**Additional information**

Usage of [yq's `merge` command](https://mikefarah.gitbook.io/yq/commands/merge) could make for a better UX (no need to use inline syntax) but would require bundling this dependency in the image for what is going to be an occasional use-case.