### PR TITLE
Fix JAVA_HOME variable for elasticsearch-keystore and etc

### DIFF
--- a/6/debian-10/Dockerfile
+++ b/6/debian-10/Dockerfile
@@ -5,7 +5,8 @@ ENV HOME="/" \
     OS_ARCH="amd64" \
     OS_FLAVOUR="debian-10" \
     OS_NAME="linux" \
-    PATH="/opt/bitnami/java/bin:/opt/bitnami/common/bin:/opt/bitnami/elasticsearch/bin:$PATH"
+    PATH="/opt/bitnami/java/bin:/opt/bitnami/common/bin:/opt/bitnami/elasticsearch/bin:$PATH" \
+    JAVA_HOME="/opt/bitnami/java"
 
 ARG ELASTICSEARCH_PLUGINS=""
 

--- a/7/debian-10/Dockerfile
+++ b/7/debian-10/Dockerfile
@@ -5,7 +5,8 @@ ENV HOME="/" \
     OS_ARCH="amd64" \
     OS_FLAVOUR="debian-10" \
     OS_NAME="linux" \
-    PATH="/opt/bitnami/java/bin:/opt/bitnami/common/bin:/opt/bitnami/elasticsearch/bin:$PATH"
+    PATH="/opt/bitnami/java/bin:/opt/bitnami/common/bin:/opt/bitnami/elasticsearch/bin:$PATH" \
+    JAVA_HOME="/opt/bitnami/java"
 
 ARG ELASTICSEARCH_PLUGINS=""
 


### PR DESCRIPTION
**Description of the change**

Added JAVA_HOME variable for elasticsearch-keystore (fixes issue https://github.com/bitnami/bitnami-docker-elasticsearch/issues/81)

**Benefits**

elasticsearch-keystore will work out of the box without any workarounds

**Possible drawbacks**

Unknown. Currently works in production (with manual change to ENV) and does not seem to have any issues

**Applicable issues**

https://github.com/bitnami/bitnami-docker-elasticsearch/issues/81

**Additional information**

There might be a better way of doing this, but it does its job and fixes the problem.
