### PR TITLE
Move heap configuration to before the first time elasticsearch is started

### DIFF
--- a/6/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/6/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -436,6 +436,8 @@ elasticsearch_initialize() {
         am_i_root && chown -R "$ELASTICSEARCH_DAEMON_USER:$ELASTICSEARCH_DAEMON_GROUP" "$dir"
     done
 
+    elasticsearch_set_heap_size
+
     if [[ -f "$ELASTICSEARCH_CONF_FILE" ]]; then
         info "Custom configuration file detected, using it..."
     else
@@ -458,7 +460,6 @@ elasticsearch_initialize() {
         elasticsearch_configure_node_type
         elasticsearch_custom_configuration
     fi
-    elasticsearch_set_heap_size
 }
 
 ########################

--- a/7/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -436,6 +436,8 @@ elasticsearch_initialize() {
         am_i_root && chown -R "$ELASTICSEARCH_DAEMON_USER:$ELASTICSEARCH_DAEMON_GROUP" "$dir"
     done
 
+    elasticsearch_set_heap_size
+
     if [[ -f "$ELASTICSEARCH_CONF_FILE" ]]; then
         info "Custom configuration file detected, using it..."
     else
@@ -458,7 +460,6 @@ elasticsearch_initialize() {
         elasticsearch_configure_node_type
         elasticsearch_custom_configuration
     fi
-    elasticsearch_set_heap_size
 }
 
 ########################


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

The change moves `elasticsearch_set_heap_size` to before the block where the configuration is generated. This makes sure the -Xmx and -Xms values are set to their configured values when `elasticsearch --version` is called. 

**Benefits**

The benefit is that when elasticsearch_cluster_configuration() calls `elasticsearch --version` then it runs with the configured memory limits instead of the default values of -Xmx1g -Xms1g. This doesn't have any implications if the container has more than 1GB memory but in a limited memory environment such as a test environment the call to `elasticsearch --version` causes the container to get OOM-killed for example in kubernetes when you have a limit on the pod less than 1GB or if you run on a memory-constrained node such as a GKE g1-small node which only has about 900MB available to containers.

**Possible drawbacks**

As far as i can tell there are no drawbacks. I have compared the resulting configurations before and after the change and it generates the same elasticsearch.yml and jvm.options files.

**Applicable issues**

**Additional information**

One way to reproduce this with helm is to run:

```
helm install es-test bitnami/elasticsearch --set master.resources.limits.memory=900Mi
```

This will setup an Elasticsearch cluster with two master nodes which just keeps crash-looping because they get OOM-killed.

Compare this to the same command run with an image built with this change:

```
helm install es-test bitnami/elasticsearch --set master.resources.limits.memory=900Mi,image.registry=mattiasa,image.repository=bitnami-docker-elasticsearch,image.tag=7.10.2-debian-10-r43-mattiasa1
```