### PR TITLE
Added support for multiple data paths.

### DIFF
--- a/6/debian-10/rootfs/opt/bitnami/scripts/elasticsearch-env.sh
+++ b/6/debian-10/rootfs/opt/bitnami/scripts/elasticsearch-env.sh
@@ -42,6 +42,7 @@ elasticsearch_env_vars=(
     ELASTICSEARCH_PLUGINS
     ELASTICSEARCH_KEYS
     ELASTICSEARCH_PORT_NUMBER
+    ELASTICSEARCH_DATA_DIR_LIST
 )
 for env_var in "${elasticsearch_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -97,5 +98,6 @@ export ELASTICSEARCH_NODE_TYPE="${ELASTICSEARCH_NODE_TYPE:-master}"
 export ELASTICSEARCH_PLUGINS="${ELASTICSEARCH_PLUGINS:-}"
 export ELASTICSEARCH_KEYS="${ELASTICSEARCH_KEYS:-}"
 export ELASTICSEARCH_PORT_NUMBER="${ELASTICSEARCH_PORT_NUMBER:-9200}"
+export ELASTICSEARCH_DATA_DIR_LIST="${ELASTICSEARCH_DATA_DIR_LIST:-}"
 
 # Custom environment variables may be defined below

--- a/6/debian-10/rootfs/opt/bitnami/scripts/elasticsearch/run.sh
+++ b/6/debian-10/rootfs/opt/bitnami/scripts/elasticsearch/run.sh
@@ -16,7 +16,7 @@ set -o pipefail
 
 # Constants
 EXEC=$(command -v elasticsearch)
-ARGS=("-p" "$ELASTICSEARCH_TMP_DIR/elasticsearch.pid" "-Epath.data=$ELASTICSEARCH_DATA_DIR")
+ARGS=("-p" "$ELASTICSEARCH_TMP_DIR/elasticsearch.pid")
 [[ -z "${ELASTICSEARCH_EXTRA_FLAGS:-}" ]] || ARGS=("${ARGS[@]}" "${ELASTICSEARCH_EXTRA_FLAGS[@]}")
 export JAVA_HOME=/opt/bitnami/java
 

--- a/7.10.2/debian-10/rootfs/opt/bitnami/scripts/elasticsearch-env.sh
+++ b/7.10.2/debian-10/rootfs/opt/bitnami/scripts/elasticsearch-env.sh
@@ -42,6 +42,7 @@ elasticsearch_env_vars=(
     ELASTICSEARCH_PLUGINS
     ELASTICSEARCH_KEYS
     ELASTICSEARCH_PORT_NUMBER
+    ELASTICSEARCH_DATA_DIR_LIST
 )
 for env_var in "${elasticsearch_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -97,5 +98,6 @@ export ELASTICSEARCH_NODE_TYPE="${ELASTICSEARCH_NODE_TYPE:-master}"
 export ELASTICSEARCH_PLUGINS="${ELASTICSEARCH_PLUGINS:-}"
 export ELASTICSEARCH_KEYS="${ELASTICSEARCH_KEYS:-}"
 export ELASTICSEARCH_PORT_NUMBER="${ELASTICSEARCH_PORT_NUMBER:-9200}"
+export ELASTICSEARCH_DATA_DIR_LIST="${ELASTICSEARCH_DATA_DIR_LIST:-}"
 
 # Custom environment variables may be defined below

--- a/7.10.2/debian-10/rootfs/opt/bitnami/scripts/elasticsearch/run.sh
+++ b/7.10.2/debian-10/rootfs/opt/bitnami/scripts/elasticsearch/run.sh
@@ -16,7 +16,7 @@ set -o pipefail
 
 # Constants
 EXEC=$(command -v elasticsearch)
-ARGS=("-p" "$ELASTICSEARCH_TMP_DIR/elasticsearch.pid" "-Epath.data=$ELASTICSEARCH_DATA_DIR")
+ARGS=("-p" "$ELASTICSEARCH_TMP_DIR/elasticsearch.pid")
 [[ -z "${ELASTICSEARCH_EXTRA_FLAGS:-}" ]] || ARGS=("${ARGS[@]}" "${ELASTICSEARCH_EXTRA_FLAGS[@]}")
 export JAVA_HOME=/opt/bitnami/java
 

--- a/7.10.2/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/7.10.2/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -126,7 +126,7 @@ elasticsearch_start() {
     is_elasticsearch_running && return
 
     debug "Starting Elasticsearch..."
-    local command=("${ELASTICSEARCH_BASE_DIR}/bin/elasticsearch" "-d" "-p" "${ELASTICSEARCH_TMP_DIR}/elasticsearch.pid" "-Epath.data=$ELASTICSEARCH_DATA_DIR")
+    local command=("${ELASTICSEARCH_BASE_DIR}/bin/elasticsearch" "-d" "-p" "${ELASTICSEARCH_TMP_DIR}/elasticsearch.pid")
     am_i_root && command=("gosu" "$ELASTICSEARCH_DAEMON_USER" "${command[@]}")
     if [[ "$BITNAMI_DEBUG" = true ]]; then
         "${command[@]}" &
@@ -432,14 +432,21 @@ elasticsearch_initialize() {
     # Exec replaces the process without creating a new one, and when the container is restarted it may have the same PID
     rm -f "$ELASTICSEARCH_TMP_DIR/elasticsearch.pid"
 
-    # Persisted data from old versions
-    if ! is_dir_empty "$ELASTICSEARCH_DATA_DIR"; then
-        debug "Detected persisted data from previous deployments"
-        [[ -d "$ELASTICSEARCH_DATA_DIR/elasticsearch" ]] && [[ -f "$ELASTICSEARCH_DATA_DIR/elasticsearch/.initialized" ]] && migrate_old_data
+    read -r -a data_dirs_list <<<"$(tr ',;' ' ' <<<"$ELASTICSEARCH_DATA_DIR_LIST")"
+    if [[ "${#data_dirs_list[@]}" -gt 0 ]]; then
+        info "Multiple data directories specified, ignoring ELASTICSEARCH_DATA_DIR option"
+    else
+        data_dirs_list+=("$ELASTICSEARCH_DATA_DIR")
+
+        # Persisted data from old versions
+        if ! is_dir_empty "$ELASTICSEARCH_DATA_DIR"; then
+            debug "Detected persisted data from previous deployments"
+            [[ -d "$ELASTICSEARCH_DATA_DIR/elasticsearch" ]] && [[ -f "$ELASTICSEARCH_DATA_DIR/elasticsearch/.initialized" ]] && migrate_old_data
+        fi
     fi
 
     debug "Ensuring expected directories/files exist..."
-    for dir in "$ELASTICSEARCH_TMP_DIR" "$ELASTICSEARCH_DATA_DIR" "$ELASTICSEARCH_LOGS_DIR" "$ELASTICSEARCH_BASE_DIR/plugins" "$ELASTICSEARCH_BASE_DIR/modules" "$ELASTICSEARCH_CONF_DIR"; do
+    for dir in "$ELASTICSEARCH_TMP_DIR" "${data_dirs_list[@]}" "$ELASTICSEARCH_LOGS_DIR" "$ELASTICSEARCH_BASE_DIR/plugins" "$ELASTICSEARCH_BASE_DIR/modules" "$ELASTICSEARCH_CONF_DIR"; do
         ensure_dir_exists "$dir"
         am_i_root && chown -R "$ELASTICSEARCH_DAEMON_USER:$ELASTICSEARCH_DAEMON_GROUP" "$dir"
     done
@@ -464,13 +471,14 @@ elasticsearch_initialize() {
         info "Setting default configuration"
         touch "$ELASTICSEARCH_CONF_FILE"
         elasticsearch_conf_set http.port "$ELASTICSEARCH_PORT_NUMBER"
-        elasticsearch_conf_set path.data "$ELASTICSEARCH_DATA_DIR"
+        elasticsearch_conf_set path.data "${data_dirs_list[@]}"
         elasticsearch_conf_set transport.tcp.port "$ELASTICSEARCH_NODE_PORT_NUMBER"
         is_boolean_yes "$ELASTICSEARCH_ACTION_DESTRUCTIVE_REQUIRES_NAME" && elasticsearch_conf_set action.destructive_requires_name "true"
         is_boolean_yes "$ELASTICSEARCH_LOCK_ALL_MEMORY" && elasticsearch_conf_set bootstrap.memory_lock "true"
         elasticsearch_cluster_configuration
         elasticsearch_configure_node_type
         elasticsearch_custom_configuration
+        [[ -d "${ELASTICSEARCH_BASE_DIR}/modules/x-pack-ml/platform/linux-x86_64/lib" ]] || elasticsearch_conf_set xpack.ml.enabled "false"
     fi
 }
 

--- a/7/debian-10/rootfs/opt/bitnami/scripts/elasticsearch-env.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/elasticsearch-env.sh
@@ -42,6 +42,7 @@ elasticsearch_env_vars=(
     ELASTICSEARCH_PLUGINS
     ELASTICSEARCH_KEYS
     ELASTICSEARCH_PORT_NUMBER
+    ELASTICSEARCH_DATA_DIR_LIST
 )
 for env_var in "${elasticsearch_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -97,5 +98,6 @@ export ELASTICSEARCH_NODE_TYPE="${ELASTICSEARCH_NODE_TYPE:-master}"
 export ELASTICSEARCH_PLUGINS="${ELASTICSEARCH_PLUGINS:-}"
 export ELASTICSEARCH_KEYS="${ELASTICSEARCH_KEYS:-}"
 export ELASTICSEARCH_PORT_NUMBER="${ELASTICSEARCH_PORT_NUMBER:-9200}"
+export ELASTICSEARCH_DATA_DIR_LIST="${ELASTICSEARCH_DATA_DIR_LIST:-}"
 
 # Custom environment variables may be defined below

--- a/7/debian-10/rootfs/opt/bitnami/scripts/elasticsearch/run.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/elasticsearch/run.sh
@@ -16,7 +16,7 @@ set -o pipefail
 
 # Constants
 EXEC=$(command -v elasticsearch)
-ARGS=("-p" "$ELASTICSEARCH_TMP_DIR/elasticsearch.pid" "-Epath.data=$ELASTICSEARCH_DATA_DIR")
+ARGS=("-p" "$ELASTICSEARCH_TMP_DIR/elasticsearch.pid")
 [[ -z "${ELASTICSEARCH_EXTRA_FLAGS:-}" ]] || ARGS=("${ARGS[@]}" "${ELASTICSEARCH_EXTRA_FLAGS[@]}")
 export JAVA_HOME=/opt/bitnami/java
 

--- a/7/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -447,7 +447,6 @@ elasticsearch_initialize() {
 
     debug "Ensuring expected directories/files exist..."
     for dir in "$ELASTICSEARCH_TMP_DIR" "${data_dirs_list[@]}" "$ELASTICSEARCH_LOGS_DIR" "$ELASTICSEARCH_BASE_DIR/plugins" "$ELASTICSEARCH_BASE_DIR/modules" "$ELASTICSEARCH_CONF_DIR"; do
-        info "Checking $dir"
         ensure_dir_exists "$dir"
         am_i_root && chown -R "$ELASTICSEARCH_DAEMON_USER:$ELASTICSEARCH_DAEMON_GROUP" "$dir"
     done

--- a/7/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -126,7 +126,7 @@ elasticsearch_start() {
     is_elasticsearch_running && return
 
     debug "Starting Elasticsearch..."
-    local command=("${ELASTICSEARCH_BASE_DIR}/bin/elasticsearch" "-d" "-p" "${ELASTICSEARCH_TMP_DIR}/elasticsearch.pid" "-Epath.data=$ELASTICSEARCH_DATA_DIR")
+    local command=("${ELASTICSEARCH_BASE_DIR}/bin/elasticsearch" "-d" "-p" "${ELASTICSEARCH_TMP_DIR}/elasticsearch.pid")
     am_i_root && command=("gosu" "$ELASTICSEARCH_DAEMON_USER" "${command[@]}")
     if [[ "$BITNAMI_DEBUG" = true ]]; then
         "${command[@]}" &
@@ -432,14 +432,22 @@ elasticsearch_initialize() {
     # Exec replaces the process without creating a new one, and when the container is restarted it may have the same PID
     rm -f "$ELASTICSEARCH_TMP_DIR/elasticsearch.pid"
 
-    # Persisted data from old versions
-    if ! is_dir_empty "$ELASTICSEARCH_DATA_DIR"; then
-        debug "Detected persisted data from previous deployments"
-        [[ -d "$ELASTICSEARCH_DATA_DIR/elasticsearch" ]] && [[ -f "$ELASTICSEARCH_DATA_DIR/elasticsearch/.initialized" ]] && migrate_old_data
+    read -r -a data_dirs_list <<<"$(tr ',;' ' ' <<<"$ELASTICSEARCH_DATA_DIR_LIST")"
+    if [[ "${#data_dirs_list[@]}" -gt 0 ]]; then
+        info "Multiple data directories specified, ignoring ELASTICSEARCH_DATA_DIR option"
+    else
+        data_dirs_list+=("$ELASTICSEARCH_DATA_DIR")
+
+        # Persisted data from old versions
+        if ! is_dir_empty "$ELASTICSEARCH_DATA_DIR"; then
+            debug "Detected persisted data from previous deployments"
+            [[ -d "$ELASTICSEARCH_DATA_DIR/elasticsearch" ]] && [[ -f "$ELASTICSEARCH_DATA_DIR/elasticsearch/.initialized" ]] && migrate_old_data
+        fi
     fi
 
     debug "Ensuring expected directories/files exist..."
-    for dir in "$ELASTICSEARCH_TMP_DIR" "$ELASTICSEARCH_DATA_DIR" "$ELASTICSEARCH_LOGS_DIR" "$ELASTICSEARCH_BASE_DIR/plugins" "$ELASTICSEARCH_BASE_DIR/modules" "$ELASTICSEARCH_CONF_DIR"; do
+    for dir in "$ELASTICSEARCH_TMP_DIR" "${data_dirs_list[@]}" "$ELASTICSEARCH_LOGS_DIR" "$ELASTICSEARCH_BASE_DIR/plugins" "$ELASTICSEARCH_BASE_DIR/modules" "$ELASTICSEARCH_CONF_DIR"; do
+        info "Checking $dir"
         ensure_dir_exists "$dir"
         am_i_root && chown -R "$ELASTICSEARCH_DAEMON_USER:$ELASTICSEARCH_DAEMON_GROUP" "$dir"
     done
@@ -464,7 +472,7 @@ elasticsearch_initialize() {
         info "Setting default configuration"
         touch "$ELASTICSEARCH_CONF_FILE"
         elasticsearch_conf_set http.port "$ELASTICSEARCH_PORT_NUMBER"
-        elasticsearch_conf_set path.data "$ELASTICSEARCH_DATA_DIR"
+        elasticsearch_conf_set path.data "${data_dirs_list[@]}"
         elasticsearch_conf_set transport.tcp.port "$ELASTICSEARCH_NODE_PORT_NUMBER"
         is_boolean_yes "$ELASTICSEARCH_ACTION_DESTRUCTIVE_REQUIRES_NAME" && elasticsearch_conf_set action.destructive_requires_name "true"
         is_boolean_yes "$ELASTICSEARCH_LOCK_ALL_MEMORY" && elasticsearch_conf_set bootstrap.memory_lock "true"

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $ docker run \
 or by making a minor change to the [`docker-compose.yml`](https://github.com/bitnami/bitnami-docker-elasticsearch/blob/master/docker-compose.yml) file present in this repository:
 
 ```yaml
-mariadb:
+elasticsearch:
   ...
   volumes:
     - /path/to/elasticsearch-data-persistence:/bitnami/elasticsearch/data
@@ -94,6 +94,19 @@ mariadb:
 ```
 
 > NOTE: As this is a non-root container, the mounted files and directories must have the proper permissions for the UID `1001`.
+
+It is also possible to use multiple volumes for data persistence by using the `ELASTICSEARCH_DATA_DIR_LIST`environment variable:
+
+```yaml
+elasticsearch:
+  ...
+  volumes:
+    - /path/to/elasticsearch-data-persistence-1:/elasticsearch/data-1
+    - /path/to/elasticsearch-data-persistence-2:/elasticsearch/data-2
+  environment:
+    - ELASTICSEARCH_DATA_DIR_LIST=/elasticsearch/data-1,/elasticsearch/data-2
+  ...
+```
 
 ## Connecting to other containers
 
@@ -208,6 +221,7 @@ Available variables:
 * `ELASTICSEARCH_KEYS`: Comma, semi-colon or space separated list of key-value pairs (key=value) to store. No defaults.
 * `ELASTICSEARCH_HEAP_SIZE`: Memory used for the Xmx and Xms java heap values. Default: **1024m**
 * `ELASTICSEARCH_FS_SNAPSHOT_REPO_PATH`: Elasticsearch file system snapshot repository path. No defaults.
+* `ELASTICSEARCH_DATA_DIR_LIST`: Comma, semi-colon or space separated list of directories to use for data storage. No defaults.
 
 ### Setting up a cluster
 


### PR DESCRIPTION
**Description of the change**

Added support for multiple data paths using the ELASTICSEARCH_DATA_DIR_LIST environment variable. I.e. the data.paths variable in the Elasticsearch configuration.
The ELASTICSEARCH_DATA_DIR environment variable is ignored in this case.
Migration of old data is skipped if multiple paths are listed.
The change should be backwards compatible. 

**Benefits**

Enables using more than one data directory in the configuration and therefore more than one mounted volume.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

Skips migration.